### PR TITLE
Custom Component를 추상화 한 Core Component 입니다.

### DIFF
--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -1,0 +1,74 @@
+import { nanoid } from 'nanoid';
+
+// TODO: 사용자가 만든 Component도 포함되어야 한다. (document.createElement('name'))으로 가능, prop 넣어주는 것은 별도로
+export interface Template {
+  parent: Element | Node;
+  children?: (Template | Element | Node | DocumentFragment)[];
+}
+
+abstract class Component extends HTMLElement {
+  private componentId = nanoid();
+
+  constructor() {
+    super();
+  }
+
+  private connectedCallback() {
+    this.render();
+    this.componentDidMounted();
+  }
+  private disconnectedCallback() {
+    this.componentDidUpdated();
+  }
+  private attributeChangedCallback() {
+    this.componentDidUnMounted();
+  }
+
+  protected componentDidMounted: () => void = () => {
+    // override
+  };
+  protected componentDidUpdated: () => void = () => {
+    // override
+  };
+  protected componentDidUnMounted: () => void = () => {
+    // override
+  };
+
+  public getComponentId() {
+    return this.componentId;
+  }
+
+  protected addEventListenerToWindow = (eventName: string, callback: (e: CustomEvent) => void) => {
+    window.addEventListener(eventName, callback.bind(this) as EventListener);
+  };
+
+  // 각 컴포넌트의 렌더링이 어떻게 될지는 알아서
+  // 사용자 자유! 이 안에 렌더할 것을 넣어주세요!
+  // TODO: 사용자의 Component일 경우엔 props 함수를 실행시켜 적용된 prop을 넣어주도록 하거나, props라는 객체 property를 가져 그걸 갱신하도록
+  // 갱신 trigger는 각 prop의 refernce가 변하면 새로 그림 (shallow equal)
+  protected abstract template: () => Template;
+
+  private composeComponents = (newTemplates: Template): Element | Node => {
+    const parent = newTemplates.parent;
+    const children = newTemplates.children;
+
+    if (children && children.length > 0) {
+      children.forEach(el => {
+        const child: Element | Node = el instanceof Element || el instanceof Node ? el : this.composeComponents(el);
+        return parent.appendChild(child);
+      });
+    }
+
+    return parent;
+  };
+
+  // Component의 최종 결과물은 항상 이 함수를 통해야 한다.
+  protected render = () => {
+    const newTemplate = this.template();
+    const rootElement = this.composeComponents(newTemplate);
+
+    this.replaceChildren(rootElement);
+  };
+}
+
+export default Component;


### PR DESCRIPTION
# Summary

Custom Component를 추상화 한 컴포넌트 입니다.

동적으로 생성되고 사라지는 Element는 이 추상 class를 구현해 Custom Component로 사용할 생각입니다.

(반대로 정적 Element는 그냥 createElement를 사용할 생각입니다.)

### why Custom Component

React처럼 컴포넌트의 LifeCycle을 제어하기 위해선 하위 컴포넌트 렌더링 과정을 상위 컴포넌트가 모두 제어할 수 있어야 하는데, 그 로직을 모두 구현하기에는 **시간적인 제약**이 너무 크다고 생각했습니다.

또한, 그 로직을 구현해도 **프론트 Bundle 자체가 그 로직으로 인해 굉장히 비대해 질 것**이라 생각했습니다.

따라서 **DOM 생명주기에 직접적으로 영향을 받아 LifeCycle 메소드를 실행**시키는 Custom Component를 사용하는 것이 좋다고 판단했습니다. (life cycle 로직이 browser 내부에 있어 프론트 로직 크기도 가벼워 지는 효과도 있다고 생각합니다.)

### FIXME

몇가지 개선해야 할 점, 개선하고 싶은 점들은 code의 FIXME로 달아놨습니다.

내용은 다음과 같습니다.

- ~~Custom Component를 Custom Component 내에서 렌더링 하기 (prop 내려주기 기능이 안되었습니다.)~~

아직 Custom Component를 Custom Component 내에서 렌더링 하는 기능이 안되었습니다.

Custom Component 특성상 다른 element와 같이 createElement로 만들 수 있지만, 문제는 prop 내려주기 기능이 안되었습니다.

props를 메소드로 넘길까, property로 달아둘까 고민중입니다. (property로 달면 나중에 JSX 적용 시에 더 수월할 것이라고 생각됩니다.)

**-> 6/17(금) state와 setState 메소드로 해결했습니다. prop을 따로 나누지 않고 외부, 내부 state를 하나로 사용하기로 했습니다.**

또한, state 갱신 시, re-render trigger는 state의 shallow equal로 반영했습니다.

## Description

추상 컴포넌트의 특징을 대략적으로 설명 드립니다.

- life cycle 메소드를 추상화하여, 필요할 때 override해서 사용할 수 있도록 했습니다.
- Template라는 type의 객체를 render합니다. Template는 nested 되어 tree구조로 element들이 이어질 수 있도록 했습니다.