### PR TITLE
전역 state관리를 위한 Core Store입니다.

### DIFF
--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -30,7 +30,6 @@ function createStore<T, P extends Dispatch>(
     e.stopPropagation();
     currentStore = reducer(currentStore, e.detail!);
 
-    // FIXME: publish를 listen하는 곳에서 어떤 결과가 올지를 type으로 알려줄 수가 없다는 것이 단점이다. -> event interface 확장을 통해 가능할 것...
     const publish = new CustomEvent<PublishPayload<T>>(name, {
       detail: {
         type: e.detail!.type,

--- a/src/core/Store.ts
+++ b/src/core/Store.ts
@@ -1,0 +1,63 @@
+export interface Dispatch {
+  type: string;
+  payload?: unknown;
+}
+
+interface PublishPayload<T> {
+  type: string;
+  payload: unknown;
+  store: T;
+}
+
+function createStore<T, P extends Dispatch>(
+  name: string,
+  callback: (store: T, action: P) => T,
+  targetElement?: HTMLElement,
+) {
+  let currentStore: T;
+  const reducer = callback;
+  const dispatchEventName = `${name}-dispatch`;
+  const listenerElement = targetElement || window;
+
+  // listener Element를 정할 수 있다는 장점이 있지만... 그것 뿐인 것 같다.
+  // 원본처럼 subscribe로 바꾸는 편이 좋을 것 같다.
+  listenerElement.addEventListener(dispatchEventName, (e: CustomEventInit<P>) => {
+    currentStore = reducer(currentStore, e.detail!);
+
+    // FIXME: publish를 listen하는 곳에서 어떤 결과가 올지를 type으로 알려줄 수가 없다는 것이 단점이다. -> event interface 확장을 통해 가능할 것...
+    // FIXME: listener가 달린 DOM 객체가 아니면 listening을 할 수 없어, 불편하다...
+    const publish = new CustomEvent<PublishPayload<T>>(name, {
+      detail: {
+        type: e.detail!.type,
+        payload: e.detail!.payload,
+        store: currentStore,
+      },
+    });
+    dispatchEvent(publish);
+  });
+
+  function dispatch({ type, payload }: P) {
+    const dispatch = new CustomEvent(dispatchEventName, {
+      detail: {
+        type,
+        payload,
+      },
+    });
+    dispatchEvent(dispatch);
+  }
+
+  const getStore = () => {
+    return currentStore;
+  };
+
+  // init!
+  // @ts-ignore
+  dispatch({ type: 'init', action: { type: '' } });
+
+  return {
+    dispatch,
+    getStore,
+  };
+}
+
+export default createStore;

--- a/src/core/store.d.ts
+++ b/src/core/store.d.ts
@@ -1,0 +1,3 @@
+interface Element {
+  addEventListener<T extends string, K extends { type?: string, payload?: any, store: any }>(type: T, listener: (this: Element, ev: Event & { detail: K }) => any, options?: boolean | AddEventListenerOptions): void;
+}


### PR DESCRIPTION
# Summary

형태는 Redux를 많이 참고했습니다.

기존 Redux와 다른 점은 Redux는 subscribe라는 메소드를 통해 listener를 받아들이고 갱신이 있을 경우 listener들에게 알려주는 반면,

저는 CustomEvent를 활용하여 subscribe 메소드를 대신했습니다.

따라서 listener의 주체는 반드시 DOM Element가 됩니다.

### CustomEvent를 이용한 이유와 장점

- 전역 store 관리를 위한 import가 줄어들어 번들 size가 줄어들고 사용하기 더 편합니다. 
    window에 event를 dispatch할 경우 다른 모듈이나 메소드의 import 등의 dependency가 없이 listen할 수 있습니다. (즉, 전역 store관리가 굉장히 편리해지고, 결합성이 더욱 줄어든다는 의미였습니다.)
- listener들에게 전파하는 과정에서 JS가 아닌 향상된 browser 엔진 로직의 혜택을 그대로 사용할 수 있을 것 같습니다.
- 기존 Redux에선 subscribe 함수를 import하여 실행해줬던 것과는 달리, addEventListener를 사용하기 때문에, 앱의 Bundle Size를 줄이는 데에도 도움이 됩니다.

### CustomEvent 걱정과 단점

 이 부분은 코드에 TODO로 달아놨습니다.

이렇게 해결할 수 있겠다 라고 하는 생각도 아래에 달아놨습니다.

- 수많은 Event가 발생했을 때 window에 listener들이 너무 많아지게 되면 성능저하의 우려가 큽니다.
-> 아직 제대로 테스트 해보진 않았습니다.
-> 해결 : Event의 bubble을 활용해 어떤 Element에서든 store 갱신 store를 달 수 있도록 변경했습니다.

- window가 아닌 다른 DOM element에 listener를 달았을 땐, 해당 Element를 가지고 있어야 한다.
-> Event capture 혹은 Bubble을 이용하면 발생한 event를 전파 해 줄 수 있을 것 같습니다. (default가 false라고 합니다.)
-> 해결 : dispatch시에 Event를 bubble 할 수 있도록 하였습니다.

### addEventListener type 확장

특정 store가 갱신되었을 때, store 이름으로 된 CustomEvent를 dispatch하는데, 그 event의 eventListener를 달아줄 때, type이 없어 곤란했었습니다.

따라서, addEventListener에 Generic을 추가 할 수 있도록 type을 확장하여, event 이름과 함께 오는 data의 type을 정해줄 수 있도록 했습니다.

```Typescript
// store.d.ts
interface Element {
  addEventListener<T extends string, K extends { type?: string, payload?: any, store: any }>(type: T, listener: (this: Element, ev: Event & { detail: K }) => any, options?: boolean | AddEventListenerOptions): void;
}
```
